### PR TITLE
Align variables to auth docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-CLIENT_ID = ""
-API_KEY = ""
-CLOUD = ""
+CLIENT_ID=""
+CLIENT_PASSWORD=""
+CLOUD=""

--- a/README.md
+++ b/README.md
@@ -1,27 +1,32 @@
 # Setup
-Update your .env file with CLIENT_ID and API_KEY from here:
-https://developer.cisco.com/docs/secure-endpoint/#!authentication/4-generate-secure-endpoint-api-access-token
-Also add CLOUD = <Cloud> (NAM, EU, APJC)
 
-Example .env:
+Update your `.env` file or environment variables with `CLIENT_ID` and
+`CLIENT_PASSWORD` from the
+[Authentication instructions](https://developer.cisco.com/docs/secure-endpoint/#!authentication).
+
+Also add `CLOUD` which can be NAM, EU or APJC.
+
+Example environment variables:
+
 ```
 CLIENT_ID="client-abcde"
-API_KEY="supersecretapikey"
+CLIENT_PASSWORD="supersecretpassword"
 CLOUD="NAM"
 ```
 
-# Requirements
+## Requirements
 
-Python version 3.5+
+Python version 3.5+.
 
-Go through the [Authentication instructions](https://developer.cisco.com/docs/secure-endpoint/#!authentication) for SecureX to integrate Secure Endpoint and create an API Client. 
+Go through the [Authentication instructions](https://developer.cisco.com/docs/secure-endpoint/#!authentication)
+for SecureX to integrate Secure Endpoint and create an API Client.
 
-Install python requirements:
-    pip install requests
-    pip install python-dotenv
+Install python requirements using `pip3 install -r requirements.txt`.
 
-# Usage
-When you first run the script you'll get authenticated and then presented with a list of organizations you belong to.
+## Usage
+
+When you first run the script you'll get authenticated and then presented with a
+list of organizations you belong to.
 
 ```
 Which organization would you like to list exclusions from?
@@ -31,11 +36,12 @@ Which organization would you like to list exclusions from?
 Input a number listed above:
 ```
 
-Choose a number from the list and you'll be presented with a list of exclusion sets for that organization and an option to export all lists.
-    
+Choose a number from the list and you'll be presented with a list of exclusion
+sets for that organization and an option to export all lists.
+
 ```
 Which exclusion set would you like to list exclusions from?
-[1] - List 
+[1] - List
 [2] - Another list
 [3] - Yet Another list
 [4] - Oh Look another list
@@ -44,20 +50,21 @@ Input a number listed above:
 ```
 
 Choose the option for the list you want to export or all lists.
-    
+
 Next you're presented with an option for CSV or JSON.
-    
+
 ```
 [1] - CSV
 [2] - JSON
 Do you want the output in JSON or CSV?
 ```
-    
-Choose which you prefer and a file will be created in the local directory of the list you selected in the format you selected.
-If you chose all lists, a file will be created for each list.    
 
-```    
+Choose which you prefer and a file will be created in the local directory of the
+list you selected in the format you selected.
+If you chose all lists, a file will be created for each list.
+
+```
 Oh Look another list.csv has been created in the current directory.
 Processing complete
 ```
-    
+

--- a/amp-04-export-exclusions.py
+++ b/amp-04-export-exclusions.py
@@ -7,10 +7,10 @@ from dotenv import load_dotenv
 # Load .env file variables
 load_dotenv()
 CLIENT_ID = os.getenv('CLIENT_ID')
-API_KEY = os.getenv('API_KEY')
+CLIENT_PASSWORD = os.getenv('CLIENT_PASSWORD')
 
-if not CLIENT_ID or not API_KEY:
-	raise "Need a CLIENT_ID and/or API_KEY variables added to .env file"
+if not CLIENT_ID or not CLIENT_PASSWORD:
+       raise "Need a CLIENT_ID and/or CLIENT_PASSWORD environment variables."
 
 CLOUD = os.getenv("CLOUD")
 if CLOUD == "NAM":
@@ -31,7 +31,7 @@ def get_se_access_token():
     :return Secure Endpoints access token
     """
 
-    auth = (CLIENT_ID, API_KEY)
+    auth = (CLIENT_ID, CLIENT_PASSWORD)
     securex_url = f"{base_securex_url}/iroh/oauth2/token"
     data = {"grant_type": "client_credentials"}
     headers = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv
+requests


### PR DESCRIPTION
This PR:
- aligns the environment variable names to the authentication documentation, `API_KEY` -> `CLIENT_PASSWORD`
- adds a `requirements.txt` file for standardised dependency management 
- lints the README.md file and does some basic rewording